### PR TITLE
CI test only supported versions of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: false
 language: node_js
 
 node_js:
-  - "6"
-  - "7"
-  - "8"
-  - "9"
-  - "10"
+  - "12"
+  - "13"
+  - "14"
+  - "15"
+  - "16"
   - "node"
 
 install:


### PR DESCRIPTION
Removing those that have passed their EOL.

https://nodejs.org/en/about/releases/